### PR TITLE
2단계 - 리팩터링(메뉴)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@
 - `MenuGroup`은 식별자와 `Name`을 가진다.
 - `Menu`는 식별자와 `DisplayedName`, `Price`, `MenuProducts`를 가진다.
 - `Menu`는 특정 `MenuGroup`에 속한다.
-- `Menu`의 `Price`은 `MenuProducts`의 금액의 합보다 적거나 같아야 한다.
-- `Menu`의 `Price`이 `MenuProducts`의 금액의 합보다 크면 `NotDisplayedMenu`가 된다.
-- `MenuProduct`는 연관된 `Product`가 있으며 `Quantity`을 가진다.
+- `Menu`의 `Price`은 `MenuProducts`의 전체 `Price`보다 적거나 같아야 한다.
+- `Menu`의 `Price`이 `MenuProducts`의 전체 `Price`보다 크면 `NotDisplayedMenu`가 된다.
+- `MenuProduct`는 `Product`와 연관되어있고 `Quantity`을 가진다.
 
 ### 매장 주문
 
@@ -192,3 +192,7 @@
 - `Order`는 접수 대기 ➜ 접수 ➜ 서빙 ➜ 계산 완료 순서로 진행된다.
 - `OrderLineItem`는 `Price`과 수량을 가진다.
 - `OrderLineItem`의 수량은 1보다 커야 한다.
+
+## TODO
+
+- [ ] MenuProduct 는 ID 생성을 DB 에게 위임하고 있는데, 테스트를 작성할 때 어떻게 값을 생성하는게 좋을까?

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@
 - `Menu`는 식별자와 `DisplayedName`, `Price`, `MenuProducts`를 가진다.
 - `Menu`는 특정 `MenuGroup`에 속한다.
 - `Menu`의 `Price`은 `MenuProducts`의 전체 `Price`보다 적거나 같아야 한다.
-- `Menu`의 `Price`이 `MenuProducts`의 전체 `Price`보다 크면 `NotDisplayedMenu`가 된다.
+- `Menu`의 `Price`이 `MenuProducts`의 전체 `Price`보다 크면 숨겨진다.
 - `MenuProduct`는 `Product`와 연관되어있고 `Quantity`을 가진다.
 
 ### 매장 주문

--- a/README.md
+++ b/README.md
@@ -196,3 +196,5 @@
 ## TODO
 
 - [ ] MenuProduct 는 ID 생성을 DB 에게 위임하고 있는데, 테스트를 작성할 때 어떻게 값을 생성하는게 좋을까?
+- [ ] Menu 생성시 전달되는 productId, quantity 로 MenuProducts 만들 때 API 를 호출하는 식으로 분리하는게 좋을까?
+- [ ] 일급 컬렉션 MenuProducts 를 사용하려다보니, 조회시 데이터가 채워지지 않음. 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 - `Menu`는 특정 `MenuGroup`에 속한다.
 - `Menu`의 `Price`은 `MenuProducts`의 금액의 합보다 적거나 같아야 한다.
 - `Menu`의 `Price`이 `MenuProducts`의 금액의 합보다 크면 `NotDisplayedMenu`가 된다.
-- `MenuProduct`는 `Price`과 `Quantity`을 가진다.
+- `MenuProduct`는 연관된 `Product`가 있으며 `Quantity`을 가진다.
 
 ### 매장 주문
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@
 
 ### 메뉴
 
-- `MenuGroup`은 식별자와 이름을 가진다.
+- `MenuGroup`은 식별자와 `Name`을 가진다.
 - `Menu`는 식별자와 `DisplayedName`, `Price`, `MenuProducts`를 가진다.
 - `Menu`는 특정 `MenuGroup`에 속한다.
 - `Menu`의 `Price`은 `MenuProducts`의 금액의 합보다 적거나 같아야 한다.
 - `Menu`의 `Price`이 `MenuProducts`의 금액의 합보다 크면 `NotDisplayedMenu`가 된다.
-- `MenuProduct`는 `Price`과 수량을 가진다.
+- `MenuProduct`는 `Price`과 `Quantity`을 가진다.
 
 ### 매장 주문
 

--- a/src/main/java/kitchenpos/common/domain/DisplayedName.java
+++ b/src/main/java/kitchenpos/common/domain/DisplayedName.java
@@ -7,7 +7,7 @@ import kitchenpos.common.Value;
 
 @Embeddable
 public class DisplayedName extends Value<DisplayedName> {
-	@Column(name = "name")
+	@Column(name = "name", nullable = false)
 	private String value;
 
 	protected DisplayedName() {

--- a/src/main/java/kitchenpos/common/domain/DisplayedName.java
+++ b/src/main/java/kitchenpos/common/domain/DisplayedName.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.domain;
+package kitchenpos.common.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -9,7 +9,7 @@ import kitchenpos.common.Value;
 
 @Embeddable
 public class Price extends Value<Price> {
-	@Column(name = "price")
+	@Column(name = "price", nullable = false)
 	private BigDecimal value;
 
 	protected Price() {

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -28,7 +28,15 @@ public class Price extends Value<Price> {
 		return new Price(a.value.add(b.value));
 	}
 
+	public static Price multiply(Price a, long b) {
+		return new Price(a.value.multiply(new BigDecimal(b)));
+	}
+
 	public BigDecimal getValue() {
 		return value;
+	}
+
+	public int compareTo(Price price) {
+		return value.compareTo(price.value);
 	}
 }

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -24,6 +24,10 @@ public class Price extends Value<Price> {
 		this.value = value;
 	}
 
+	public static Price add(Price a, Price b) {
+		return new Price(a.value.add(b.value));
+	}
+
 	public BigDecimal getValue() {
 		return value;
 	}

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.domain;
+package kitchenpos.common.domain;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/kitchenpos/common/domain/Profanities.java
+++ b/src/main/java/kitchenpos/common/domain/Profanities.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.domain;
+package kitchenpos.common.domain;
 
 public interface Profanities {
 	boolean contains(String name);

--- a/src/main/java/kitchenpos/common/infra/DefaultProfanities.java
+++ b/src/main/java/kitchenpos/common/infra/DefaultProfanities.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.infra;
+package kitchenpos.common.infra;
 
 import java.net.URI;
 
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import kitchenpos.products.tobe.domain.Profanities;
+import kitchenpos.common.domain.Profanities;
 
 @Component
 public class DefaultProfanities implements Profanities {

--- a/src/main/java/kitchenpos/menus/tobe/application/menu/MenuService.java
+++ b/src/main/java/kitchenpos/menus/tobe/application/menu/MenuService.java
@@ -1,0 +1,96 @@
+package kitchenpos.menus.tobe.application.menu;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
+import kitchenpos.common.domain.Profanities;
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuProduct;
+import kitchenpos.menus.tobe.domain.menu.MenuProducts;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
+import kitchenpos.menus.tobe.domain.menu.Quantity;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+import kitchenpos.menus.tobe.ui.menu.MenuCreateRequest;
+import kitchenpos.menus.tobe.ui.menu.MenuPriceChangeRequest;
+import kitchenpos.products.tobe.domain.Product;
+import kitchenpos.products.tobe.domain.ProductRepository;
+
+@Service(value = "TobeMenuService")
+public class MenuService {
+	private final MenuGroupRepository menuGroupRepository;
+	private final ProductRepository productRepository;
+	private final Profanities profanities;
+	private final MenuRepository menuRepository;
+
+	public MenuService(
+		MenuGroupRepository menuGroupRepository,
+		ProductRepository productRepository,
+		Profanities profanities,
+		MenuRepository menuRepository
+	) {
+		this.menuGroupRepository = menuGroupRepository;
+		this.productRepository = productRepository;
+		this.profanities = profanities;
+		this.menuRepository = menuRepository;
+	}
+
+	@Transactional
+	public Menu create(MenuCreateRequest request) {
+		DisplayedName name = new DisplayedName(request.getName(), profanities);
+		Price price = new Price(new BigDecimal(request.getPrice()));
+		boolean displayed = request.getDisplayed();
+
+		MenuProducts menuProducts = new MenuProducts(
+			request.getMenuProducts().stream().map(
+				dto -> {
+					Product product = productRepository.findById(dto.getProductId())
+						.orElseThrow(IllegalArgumentException::new);
+					Quantity quantity = new Quantity(dto.getQuantity());
+					return new MenuProduct(product, quantity);
+				}
+			).collect(Collectors.toList()));
+
+		MenuGroup menuGroup = menuGroupRepository.findById(request.getMenuGroupId())
+			.orElseThrow(NoSuchElementException::new);
+
+		Menu menu = new Menu(name, price, displayed, menuProducts, menuGroup);
+
+		return menuRepository.save(menu);
+	}
+
+	@Transactional
+	public Menu changePrice(UUID menuId, MenuPriceChangeRequest request) {
+		Price price = new Price(new BigDecimal(request.getPrice()));
+		Menu menu = menuRepository.findById(menuId).orElseThrow(NoSuchElementException::new);
+		menu.changePrice(price);
+		return menu;
+	}
+
+	@Transactional
+	public Menu display(UUID menuId) {
+		Menu menu = menuRepository.findById(menuId).orElseThrow(NoSuchElementException::new);
+		menu.display();
+		return menu;
+	}
+
+	@Transactional
+	public Menu hide(UUID menuId) {
+		Menu menu = menuRepository.findById(menuId).orElseThrow(NoSuchElementException::new);
+		menu.hide();
+		return menu;
+	}
+
+	@Transactional(readOnly = true)
+	public List<Menu> findAll() {
+		return menuRepository.findAll();
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/application/menugroup/MenuGroupService.java
+++ b/src/main/java/kitchenpos/menus/tobe/application/menugroup/MenuGroupService.java
@@ -1,0 +1,32 @@
+package kitchenpos.menus.tobe.application.menugroup;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+import kitchenpos.menus.tobe.domain.menugroup.Name;
+import kitchenpos.menus.tobe.ui.menugroup.MenuGroupCreateRequest;
+
+@Service(value = "TobeMenuGroupService")
+public class MenuGroupService {
+	private final MenuGroupRepository menuGroupRepository;
+
+	public MenuGroupService(final MenuGroupRepository menuGroupRepository) {
+		this.menuGroupRepository = menuGroupRepository;
+	}
+
+	@Transactional
+	public MenuGroup create(final MenuGroupCreateRequest request) {
+		Name name = new Name(request.getName());
+		MenuGroup menuGroup = new MenuGroup(name);
+		return menuGroupRepository.save(menuGroup);
+	}
+
+	@Transactional(readOnly = true)
+	public List<MenuGroup> findAll() {
+		return menuGroupRepository.findAll();
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
@@ -70,6 +70,12 @@ public class Menu {
 		this.price = price;
 	}
 
+	public void updateDisplayed() {
+		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
+			this.displayed = false;
+		}
+	}
+
 	private void validate(Price price, MenuProducts menuProducts) {
 		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
 			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
@@ -28,6 +28,12 @@ public class Menu {
 	@Embedded
 	private Price price;
 
+	@Column(name = "displayed", nullable = false)
+	private boolean displayed;
+
+	@Embedded
+	private MenuProducts menuProducts;
+
 	@ManyToOne(optional = false)
 	@JoinColumn(
 		name = "menu_group_id",
@@ -36,16 +42,20 @@ public class Menu {
 	)
 	private MenuGroup menuGroup;
 
-	// TODO : menuProducts
-
 	protected Menu() {
 
 	}
 
-	public Menu(DisplayedName name, Price price, MenuGroup menuGroup) {
+	public Menu(DisplayedName name, Price price, boolean displayed, MenuProducts menuProducts, MenuGroup menuGroup) {
+		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
+			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");
+		}
+
 		this.id = UUID.randomUUID();
 		this.name = name;
 		this.price = price;
+		this.displayed = displayed;
+		this.menuProducts = menuProducts;
 		this.menuGroup = menuGroup;
 	}
 
@@ -59,6 +69,14 @@ public class Menu {
 
 	public Price getPrice() {
 		return price;
+	}
+
+	public boolean isDisplayed() {
+		return displayed;
+	}
+
+	public MenuProducts getMenuProducts() {
+		return menuProducts;
 	}
 
 	public MenuGroup getMenuGroup() {

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
@@ -47,16 +47,33 @@ public class Menu {
 	}
 
 	public Menu(DisplayedName name, Price price, boolean displayed, MenuProducts menuProducts, MenuGroup menuGroup) {
-		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
-			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");
-		}
-
+		validate(price, menuProducts);
 		this.id = UUID.randomUUID();
 		this.name = name;
 		this.price = price;
 		this.displayed = displayed;
 		this.menuProducts = menuProducts;
 		this.menuGroup = menuGroup;
+	}
+
+	public void display() {
+		validate(price, menuProducts);
+		displayed = true;
+	}
+
+	public void hide() {
+		displayed = false;
+	}
+
+	public void changePrice(Price price) {
+		validate(price, menuProducts);
+		this.price = price;
+	}
+
+	private void validate(Price price, MenuProducts menuProducts) {
+		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
+			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");
+		}
 	}
 
 	public UUID getId() {

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Menu.java
@@ -1,0 +1,67 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+
+@Table(name = "menu")
+@Entity(name = "TobeMenu")
+public class Menu {
+	@Column(name = "id", columnDefinition = "varbinary(16)")
+	@Id
+	private UUID id;
+
+	@Embedded
+	private DisplayedName name;
+
+	@Embedded
+	private Price price;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(
+		name = "menu_group_id",
+		columnDefinition = "varbinary(16)",
+		foreignKey = @ForeignKey(name = "fk_menu_to_menu_group")
+	)
+	private MenuGroup menuGroup;
+
+	// TODO : menuProducts
+
+	protected Menu() {
+
+	}
+
+	public Menu(DisplayedName name, Price price, MenuGroup menuGroup) {
+		this.id = UUID.randomUUID();
+		this.name = name;
+		this.price = price;
+		this.menuGroup = menuGroup;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public DisplayedName getName() {
+		return name;
+	}
+
+	public Price getPrice() {
+		return price;
+	}
+
+	public MenuGroup getMenuGroup() {
+		return menuGroup;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProduct.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProduct.java
@@ -1,0 +1,51 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import kitchenpos.products.tobe.domain.Product;
+
+@Table(name = "menu_product")
+@Entity(name = "TobeMenuProduct")
+public class MenuProduct {
+	@Column(name = "seq")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	private Long seq;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(
+		name = "product_id",
+		columnDefinition = "varbinary(16)",
+		foreignKey = @ForeignKey(name = "fk_menu_product_to_product")
+	)
+	private Product product;
+
+	@Embedded
+	private Quantity quantity;
+
+	protected MenuProduct() {
+
+	}
+
+	public MenuProduct(Product product, Quantity quantity) {
+		this.product = product;
+		this.quantity = quantity;
+	}
+
+	public Product getProduct() {
+		return product;
+	}
+
+	public Quantity getQuantity() {
+		return quantity;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProducts.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProducts.java
@@ -26,6 +26,10 @@ public class MenuProducts {
 	}
 
 	public MenuProducts(List<MenuProduct> values) {
+		if (values == null || values.isEmpty()) {
+			throw new IllegalArgumentException("메뉴상품은 한개 이상이어야 합니다.");
+		}
+
 		this.values = values;
 	}
 

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProducts.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuProducts.java
@@ -1,0 +1,45 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+
+import kitchenpos.common.domain.Price;
+
+@Embeddable
+public class MenuProducts {
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+	@JoinColumn(
+		name = "menu_id",
+		nullable = false,
+		columnDefinition = "varbinary(16)",
+		foreignKey = @ForeignKey(name = "fk_menu_product_to_menu")
+	)
+	private List<MenuProduct> values;
+
+	protected MenuProducts() {
+
+	}
+
+	public MenuProducts(List<MenuProduct> values) {
+		this.values = values;
+	}
+
+	public List<MenuProduct> getValues() {
+		return values;
+	}
+
+	public Price getTotalPrice() {
+		return values.stream()
+			.map(menuProduct ->
+				Price.multiply(
+					menuProduct.getProduct().getPrice(),
+					menuProduct.getQuantity().getValue()))
+			.reduce(Price::add)
+			.get();
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuRepository.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/MenuRepository.java
@@ -1,0 +1,18 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuRepository {
+	Menu save(Menu menu);
+
+	Optional<Menu> findById(UUID id);
+
+	List<Menu> findAll();
+
+	List<Menu> findAllByIdIn(List<UUID> ids);
+
+	List<Menu> findAllByProductId(UUID productId);
+}
+

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Quantity.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Quantity.java
@@ -1,9 +1,18 @@
 package kitchenpos.menus.tobe.domain.menu;
 
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
 import kitchenpos.common.Value;
 
+@Embeddable
 public class Quantity extends Value<Quantity> {
-	private final long value;
+	@Column(name = "quantity", nullable = false)
+	private long value;
+
+	protected Quantity() {
+
+	}
 
 	public Quantity(long value) {
 		if (value < 0) {

--- a/src/main/java/kitchenpos/menus/tobe/domain/menu/Quantity.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menu/Quantity.java
@@ -1,0 +1,19 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import kitchenpos.common.Value;
+
+public class Quantity extends Value<Quantity> {
+	private final long value;
+
+	public Quantity(long value) {
+		if (value < 0) {
+			throw new IllegalArgumentException("수량은 0 이상이어야 합니다.");
+		}
+
+		this.value = value;
+	}
+
+	public long getValue() {
+		return value;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroup.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroup.java
@@ -1,0 +1,52 @@
+package kitchenpos.menus.tobe.domain.menugroup;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Table(name = "menu_group")
+@Entity(name = "TobeMenuGroup")
+public class MenuGroup {
+	@Id
+	@Column(name = "id", columnDefinition = "varbinary(16)")
+	private UUID id;
+	@Embedded
+	private Name name;
+
+	protected MenuGroup() {
+
+	}
+
+	public MenuGroup(Name name) {
+		this.id = UUID.randomUUID();
+		this.name = name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		MenuGroup menuGroup = (MenuGroup)o;
+		return id.equals(menuGroup.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public Name getName() {
+		return name;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroupRepository.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroupRepository.java
@@ -1,0 +1,13 @@
+package kitchenpos.menus.tobe.domain.menugroup;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuGroupRepository {
+	MenuGroup save(MenuGroup menuGroup);
+
+	Optional<MenuGroup> findById(UUID id);
+
+	List<MenuGroup> findAll();
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menugroup/Name.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menugroup/Name.java
@@ -1,0 +1,28 @@
+package kitchenpos.menus.tobe.domain.menugroup;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import kitchenpos.common.Value;
+
+@Embeddable
+public class Name extends Value<Name> {
+	@Column(name = "name")
+	private String value;
+
+	protected Name() {
+
+	}
+
+	public Name(String value) {
+		if (value == null || value.length() == 0) {
+			throw new IllegalArgumentException("이름은 빈 값일 수 없습니다.");
+		}
+
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/domain/menugroup/Name.java
+++ b/src/main/java/kitchenpos/menus/tobe/domain/menugroup/Name.java
@@ -7,7 +7,7 @@ import kitchenpos.common.Value;
 
 @Embeddable
 public class Name extends Value<Name> {
-	@Column(name = "name")
+	@Column(name = "name", nullable = false)
 	private String value;
 
 	protected Name() {

--- a/src/main/java/kitchenpos/menus/tobe/infra/menu/JpaMenuRepository.java
+++ b/src/main/java/kitchenpos/menus/tobe/infra/menu/JpaMenuRepository.java
@@ -1,0 +1,19 @@
+package kitchenpos.menus.tobe.infra.menu;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
+
+@Repository(value = "TobeJpaMenuRepository")
+public interface JpaMenuRepository extends MenuRepository, JpaRepository<Menu, UUID> {
+    @Query("select m from Menu m, MenuProduct mp where mp.product.id = :productId")
+    @Override
+    List<Menu> findAllByProductId(@Param("productId") UUID productId);
+}

--- a/src/main/java/kitchenpos/menus/tobe/infra/menugroup/JpaMenuGroupRepository.java
+++ b/src/main/java/kitchenpos/menus/tobe/infra/menugroup/JpaMenuGroupRepository.java
@@ -1,0 +1,14 @@
+package kitchenpos.menus.tobe.infra.menugroup;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+
+@Repository(value = "TobeJpaMenuGroupRepository")
+public interface JpaMenuGroupRepository extends MenuGroupRepository, JpaRepository<MenuGroup, UUID> {
+
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuCreateRequest.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuCreateRequest.java
@@ -1,0 +1,59 @@
+package kitchenpos.menus.tobe.ui.menu;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+public class MenuCreateRequest {
+	@NotBlank
+	private String name;
+	@NotNull
+	private Long price;
+	@NotNull
+	private UUID menuGroupId;
+	@NotNull
+	private Boolean displayed;
+	@NotEmpty
+	private List<MenuProductDto> menuProducts;
+
+	public MenuCreateRequest() {
+
+	}
+
+	public MenuCreateRequest(
+		String name,
+		Long price,
+		UUID menuGroupId,
+		Boolean displayed,
+		List<MenuProductDto> menuProducts
+	) {
+		this.name = name;
+		this.price = price;
+		this.menuGroupId = menuGroupId;
+		this.displayed = displayed;
+		this.menuProducts = menuProducts;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getPrice() {
+		return price;
+	}
+
+	public UUID getMenuGroupId() {
+		return menuGroupId;
+	}
+
+	public Boolean getDisplayed() {
+		return displayed;
+	}
+
+	public List<MenuProductDto> getMenuProducts() {
+		return menuProducts;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuPriceChangeRequest.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuPriceChangeRequest.java
@@ -1,0 +1,20 @@
+package kitchenpos.menus.tobe.ui.menu;
+
+import javax.validation.constraints.NotNull;
+
+public class MenuPriceChangeRequest {
+	@NotNull
+	private Long price;
+
+	public MenuPriceChangeRequest() {
+
+	}
+
+	public MenuPriceChangeRequest(Long price) {
+		this.price = price;
+	}
+
+	public Long getPrice() {
+		return price;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuProductDto.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuProductDto.java
@@ -1,0 +1,25 @@
+package kitchenpos.menus.tobe.ui.menu;
+
+import java.util.UUID;
+
+public class MenuProductDto {
+	private UUID productId;
+	private long quantity;
+
+	public MenuProductDto() {
+
+	}
+
+	public MenuProductDto(UUID productId, long quantity) {
+		this.productId = productId;
+		this.quantity = quantity;
+	}
+
+	public UUID getProductId() {
+		return productId;
+	}
+
+	public long getQuantity() {
+		return quantity;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuRestController.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menu/MenuRestController.java
@@ -1,0 +1,59 @@
+package kitchenpos.menus.tobe.ui.menu;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kitchenpos.menus.tobe.application.menu.MenuService;
+import kitchenpos.menus.tobe.domain.menu.Menu;
+
+@RequestMapping("/api/menus")
+@RestController(value = "TobeMenuRestController")
+public class MenuRestController {
+	private final MenuService menuService;
+
+	public MenuRestController(final MenuService menuService) {
+		this.menuService = menuService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Menu> create(@Valid @RequestBody final MenuCreateRequest request) {
+		final Menu response = menuService.create(request);
+		return ResponseEntity.created(URI.create("/api/menus/" + response.getId()))
+			.body(response);
+	}
+
+	@PutMapping("/{menuId}/price")
+	public ResponseEntity<Menu> changePrice(
+		@PathVariable final UUID menuId,
+		@RequestBody final MenuPriceChangeRequest request
+	) {
+		return ResponseEntity.ok(menuService.changePrice(menuId, request));
+	}
+
+	@PutMapping("/{menuId}/display")
+	public ResponseEntity<Menu> display(@PathVariable final UUID menuId) {
+		return ResponseEntity.ok(menuService.display(menuId));
+	}
+
+	@PutMapping("/{menuId}/hide")
+	public ResponseEntity<Menu> hide(@PathVariable final UUID menuId) {
+		return ResponseEntity.ok(menuService.hide(menuId));
+	}
+
+	@GetMapping
+	public ResponseEntity<List<Menu>> findAll() {
+		return ResponseEntity.ok(menuService.findAll());
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menugroup/MenuGroupCreateRequest.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menugroup/MenuGroupCreateRequest.java
@@ -1,0 +1,20 @@
+package kitchenpos.menus.tobe.ui.menugroup;
+
+import javax.validation.constraints.NotBlank;
+
+public class MenuGroupCreateRequest {
+	@NotBlank
+	private String name;
+
+	public MenuGroupCreateRequest() {
+
+	}
+
+	public MenuGroupCreateRequest(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/kitchenpos/menus/tobe/ui/menugroup/MenuGroupRestController.java
+++ b/src/main/java/kitchenpos/menus/tobe/ui/menugroup/MenuGroupRestController.java
@@ -1,0 +1,38 @@
+package kitchenpos.menus.tobe.ui.menugroup;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kitchenpos.menus.tobe.application.menugroup.MenuGroupService;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+
+@RequestMapping("/api/menu-groups")
+@RestController(value = "TobeMenuGroupRestController")
+public class MenuGroupRestController {
+	private final MenuGroupService menuGroupService;
+
+	public MenuGroupRestController(MenuGroupService menuGroupService) {
+		this.menuGroupService = menuGroupService;
+	}
+
+	@PostMapping
+	public ResponseEntity<MenuGroup> create(@Valid @RequestBody MenuGroupCreateRequest request) {
+		MenuGroup response = menuGroupService.create(request);
+		return ResponseEntity.created(URI.create("/api/menu-groups/" + response.getId()))
+			.body(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<List<MenuGroup>> findAll() {
+		return ResponseEntity.ok(menuGroupService.findAll());
+	}
+}

--- a/src/main/java/kitchenpos/menus/ui/MenuGroupRestController.java
+++ b/src/main/java/kitchenpos/menus/ui/MenuGroupRestController.java
@@ -9,7 +9,7 @@ import java.net.URI;
 import java.util.List;
 
 @RequestMapping("/api/menu-groups")
-@RestController
+// @RestController
 public class MenuGroupRestController {
     private final MenuGroupService menuGroupService;
 

--- a/src/main/java/kitchenpos/menus/ui/MenuRestController.java
+++ b/src/main/java/kitchenpos/menus/ui/MenuRestController.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RequestMapping("/api/menus")
-@RestController
+// @RestController
 public class MenuRestController {
     private final MenuService menuService;
 

--- a/src/main/java/kitchenpos/products/tobe/application/ProductService.java
+++ b/src/main/java/kitchenpos/products/tobe/application/ProductService.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kitchenpos.products.tobe.domain.DisplayedName;
-import kitchenpos.products.tobe.domain.Price;
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
 import kitchenpos.products.tobe.domain.Product;
 import kitchenpos.products.tobe.domain.ProductRepository;
-import kitchenpos.products.tobe.domain.Profanities;
+import kitchenpos.common.domain.Profanities;
 import kitchenpos.products.tobe.ui.ProductCreateRequest;
 import kitchenpos.products.tobe.ui.ProductPriceChangeRequest;
 

--- a/src/main/java/kitchenpos/products/tobe/application/ProductService.java
+++ b/src/main/java/kitchenpos/products/tobe/application/ProductService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
 import kitchenpos.products.tobe.domain.Product;
 import kitchenpos.products.tobe.domain.ProductRepository;
 import kitchenpos.common.domain.Profanities;
@@ -20,10 +22,16 @@ import kitchenpos.products.tobe.ui.ProductPriceChangeRequest;
 public class ProductService {
 	private final ProductRepository productRepository;
 	private final Profanities profanities;
+	private final MenuRepository menuRepository;
 
-	public ProductService(ProductRepository productRepository, Profanities profanities) {
+	public ProductService(
+		ProductRepository productRepository,
+		Profanities profanities,
+		MenuRepository menuRepository
+	) {
 		this.productRepository = productRepository;
 		this.profanities = profanities;
+		this.menuRepository = menuRepository;
 	}
 
 	@Transactional
@@ -34,11 +42,12 @@ public class ProductService {
 	}
 
 	@Transactional
-	// TODO : 상품의 가격이 변경될 때 메뉴의 가격이 메뉴에 속한 상품 금액의 합보다 크면 메뉴가 숨겨진다.
 	public Product changePrice(UUID id, ProductPriceChangeRequest request) {
 		Product product = productRepository.findById(id).orElseThrow(NoSuchElementException::new);
 		Price price = new Price(new BigDecimal(request.getPrice()));
 		product.changePrice(price);
+		List<Menu> menus = menuRepository.findAllByProductId(product.getId());
+		menus.forEach(Menu::updateDisplayed);
 		return product;
 	}
 

--- a/src/main/java/kitchenpos/products/tobe/domain/Product.java
+++ b/src/main/java/kitchenpos/products/tobe/domain/Product.java
@@ -6,10 +6,11 @@ import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
 
 @Table(name = "product")
 @Entity(name = "TobeProduct")

--- a/src/test/java/kitchenpos/TobeFixtures.java
+++ b/src/test/java/kitchenpos/TobeFixtures.java
@@ -2,8 +2,8 @@ package kitchenpos;
 
 import java.math.BigDecimal;
 
-import kitchenpos.products.tobe.domain.DisplayedName;
-import kitchenpos.products.tobe.domain.Price;
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
 import kitchenpos.products.tobe.domain.Product;
 
 public class TobeFixtures {

--- a/src/test/java/kitchenpos/common/domain/DisplayedNameTest.java
+++ b/src/test/java/kitchenpos/common/domain/DisplayedNameTest.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.domain;
+package kitchenpos.common.domain;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -43,6 +43,19 @@ class PriceTest {
 		assertThat(c).isEqualTo(new Price(new BigDecimal(cValue)));
 	}
 
+	@ParameterizedTest
+	@CsvSource({"10000, 2, 20000", "15000, 3, 45000"})
+	void 곱셈(long aValue, long bValue, long cValue) {
+		// given
+		Price a = new Price(new BigDecimal(aValue));
+
+		// when
+		Price c = Price.multiply(a, bValue);
+
+		// then
+		assertThat(c).isEqualTo(new Price(new BigDecimal(cValue)));
+	}
+
 	@Test
 	void 동등성() {
 		// given

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -26,6 +27,20 @@ class PriceTest {
 	void 빈_값이거나_음수일_경우_가격을_생성할_수_없다(BigDecimal value) {
 		// given & when & then
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new Price(value));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"10000, 15000, 25000", "18000, 2000, 20000"})
+	void 덧셈(long aValue, long bValue, long cValue) {
+		// given
+		Price a = new Price(new BigDecimal(aValue));
+		Price b = new Price(new BigDecimal(bValue));
+
+		// when
+		Price c = Price.add(a, b);
+
+		// then
+		assertThat(c).isEqualTo(new Price(new BigDecimal(cValue)));
 	}
 
 	@Test

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -1,4 +1,4 @@
-package kitchenpos.products.tobe.domain;
+package kitchenpos.common.domain;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/kitchenpos/common/domain/fixture/DisplayedNameFixture.java
+++ b/src/test/java/kitchenpos/common/domain/fixture/DisplayedNameFixture.java
@@ -1,0 +1,9 @@
+package kitchenpos.common.domain.fixture;
+
+import kitchenpos.common.domain.DisplayedName;
+
+public class DisplayedNameFixture {
+	public static DisplayedName 이름(String value) {
+		return new DisplayedName(value, text -> false);
+	}
+}

--- a/src/test/java/kitchenpos/common/domain/fixture/PriceFixture.java
+++ b/src/test/java/kitchenpos/common/domain/fixture/PriceFixture.java
@@ -1,0 +1,11 @@
+package kitchenpos.common.domain.fixture;
+
+import java.math.BigDecimal;
+
+import kitchenpos.common.domain.Price;
+
+public class PriceFixture {
+	public static Price 가격(long value) {
+		return new Price(new BigDecimal(value));
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/application/menu/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/application/menu/MenuServiceTest.java
@@ -1,0 +1,266 @@
+package kitchenpos.menus.tobe.application.menu;
+
+import static kitchenpos.Fixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.common.domain.Profanities;
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuFixture;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+import kitchenpos.menus.tobe.domain.menugroup.fixture.MenuGroupFixture;
+import kitchenpos.menus.tobe.infra.menu.InMemoryMenuRepository;
+import kitchenpos.menus.tobe.infra.menugroup.InMemoryMenuGroupRepository;
+import kitchenpos.menus.tobe.ui.menu.MenuCreateRequest;
+import kitchenpos.menus.tobe.ui.menu.MenuPriceChangeRequest;
+import kitchenpos.menus.tobe.ui.menu.MenuProductDto;
+import kitchenpos.products.tobe.domain.Product;
+import kitchenpos.products.tobe.domain.ProductRepository;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
+import kitchenpos.products.tobe.infra.InMemoryProductRepository;
+
+public class MenuServiceTest {
+	private MenuRepository menuRepository;
+	private MenuGroupRepository menuGroupRepository;
+	private ProductRepository productRepository;
+	private Profanities profanities;
+	private MenuService menuService;
+	private UUID menuGroupId;
+	private Product product;
+
+	@BeforeEach
+	void setUp() {
+		menuRepository = new InMemoryMenuRepository();
+		menuGroupRepository = new InMemoryMenuGroupRepository();
+		productRepository = new InMemoryProductRepository();
+		profanities = text -> Stream.of("비속어", "욕설").anyMatch(text::contains);
+		menuService = new MenuService(menuGroupRepository, productRepository, profanities, menuRepository);
+		menuGroupId = menuGroupRepository.save(MenuGroupFixture.메뉴그룹("추천메뉴")).getId();
+		product = productRepository.save(ProductFixture.상품("후라이드", 16_000L));
+	}
+
+	@Test
+	void 한개_이상의_등록된_상품으로_메뉴를_등록할_수_있다() {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			19_000L,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), 2L))
+		);
+
+		// when
+		Menu actual = menuService.create(request);
+
+		// then
+		assertThat(actual).isNotNull();
+		assertAll(
+			() -> assertThat(actual.getId()).isNotNull(),
+			() -> assertThat(actual.getName().getValue()).isEqualTo(request.getName()),
+			() -> assertThat(actual.getPrice().getValue().longValue()).isEqualTo(request.getPrice()),
+			() -> assertThat(actual.getMenuGroup().getId()).isEqualTo(request.getMenuGroupId()),
+			() -> assertThat(actual.isDisplayed()).isEqualTo(request.getDisplayed().booleanValue()),
+			() -> assertThat(actual.getMenuProducts()).isNotNull(),
+			() -> assertThat(actual.getMenuProducts().getValues()).hasSize(1)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("menuProducts")
+	void 상품이_없으면_등록할_수_없다(List<MenuProductDto> menuProducts) {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			19_000L,
+			menuGroupId,
+			true,
+			menuProducts
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	private static List<Arguments> menuProducts() {
+		return Arrays.asList(
+			Arguments.of(Collections.emptyList()),
+			Arguments.of(Collections.singletonList(new MenuProductDto(INVALID_ID, 2L)))
+		);
+	}
+
+	@Test
+	void 메뉴에_속한_상품의_수량은_0개_이상이어야_한다() {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			19_000L,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), -1L))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = "-1000")
+	void 메뉴의_가격이_올바르지_않으면_등록할_수_없다(long price) {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			price,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), 2L))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 메뉴에_속한_상품_금액의_합은_메뉴의_가격보다_크거나_같아야_한다() {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			70_000L,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), 2L))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	void 메뉴는_특정_메뉴_그룹에_속해야_한다(UUID menuGroupId) {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			"후라이드+후라이드",
+			19_000L,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), 2L))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(NoSuchElementException.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"비속어", "욕설이 포함된 이름"})
+	@NullSource
+	void 메뉴의_이름이_올바르지_않으면_등록할_수_없다(String name) {
+		// given
+		MenuCreateRequest request = new MenuCreateRequest(
+			name,
+			19_000L,
+			menuGroupId,
+			true,
+			Collections.singletonList(new MenuProductDto(product.getId(), 2L))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 메뉴의_가격을_변경할_수_있다() {
+		// given
+		UUID menuId = menuRepository.save(MenuFixture.전시_메뉴()).getId();
+		MenuPriceChangeRequest request = new MenuPriceChangeRequest(16_000L);
+
+		// when
+		Menu actual = menuService.changePrice(menuId, request);
+
+		// then
+		assertThat(actual.getPrice()).isEqualTo(new Price(new BigDecimal(request.getPrice())));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = "-1000")
+	void 메뉴의_가격이_올바르지_않으면_변경할_수_없다(long price) {
+		// given
+		UUID menuId = menuRepository.save(MenuFixture.전시_메뉴()).getId();
+		MenuPriceChangeRequest request = new MenuPriceChangeRequest(price);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.changePrice(menuId, request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 메뉴의_가격이_메뉴에_속한_상품_금액의_합보다_높을_경우_메뉴를_노출할_수_없다() {
+		// given
+		UUID menuId = menuRepository.save(MenuFixture.전시_메뉴(new Price(new BigDecimal(19_000L)))).getId();
+		MenuPriceChangeRequest request = new MenuPriceChangeRequest(70_000L);
+
+		// when & then
+		assertThatThrownBy(() -> menuService.changePrice(menuId, request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 메뉴를_노출할_수_있다() {
+		// given
+		UUID menuId = menuRepository.save(MenuFixture.숨김_메뉴()).getId();
+
+		// when
+		Menu actual = menuService.display(menuId);
+
+		// then
+		assertThat(actual.isDisplayed()).isTrue();
+	}
+
+	@Test
+	void 메뉴를_숨길_수_있다() {
+		// given
+		UUID menuId = menuRepository.save(MenuFixture.전시_메뉴()).getId();
+
+		// when
+		Menu actual = menuService.hide(menuId);
+
+		// then
+		assertThat(actual.isDisplayed()).isFalse();
+	}
+
+	@Test
+	void 메뉴의_목록을_조회할_수_있다() {
+		// given
+		menuRepository.save(MenuFixture.전시_메뉴());
+
+		// when
+		List<Menu> actual = menuService.findAll();
+
+		// then
+		assertThat(actual).hasSize(1);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/application/menugroup/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/application/menugroup/MenuGroupServiceTest.java
@@ -1,0 +1,53 @@
+package kitchenpos.menus.tobe.application.menugroup;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+import kitchenpos.menus.tobe.domain.menugroup.Name;
+import kitchenpos.menus.tobe.infra.menugroup.InMemoryMenuGroupRepository;
+import kitchenpos.menus.tobe.ui.menugroup.MenuGroupCreateRequest;
+
+public class MenuGroupServiceTest {
+	private MenuGroupRepository menuGroupRepository;
+	private MenuGroupService menuGroupService;
+
+	@BeforeEach
+	void setUp() {
+		menuGroupRepository = new InMemoryMenuGroupRepository();
+		menuGroupService = new MenuGroupService(menuGroupRepository);
+	}
+
+	@Test
+	void 메뉴그룹을_등록할_수_있다() {
+		// given
+		MenuGroupCreateRequest request = new MenuGroupCreateRequest("추천메뉴");
+
+		// when
+		MenuGroup actual = menuGroupService.create(request);
+
+		// then
+		assertThat(actual).isNotNull();
+		assertAll(
+			() -> assertThat(actual.getId()).isNotNull(),
+			() -> assertThat(actual.getName()).isEqualTo(new Name(request.getName()))
+		);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 이름이_빈_값이면_등록할_수_없다(String name) {
+		// given
+		MenuGroupCreateRequest request = new MenuGroupCreateRequest(name);
+
+		// when & then
+		assertThatThrownBy(() -> menuGroupService.create(request))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductTest.java
@@ -1,0 +1,28 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.products.tobe.domain.Product;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
+
+class MenuProductTest {
+	@Test
+	void 메뉴상품을_생성할_수_있다() {
+		// given
+		Product product = ProductFixture.상품("강정치킨", 17_000L);
+		Quantity quantity = new Quantity(25L);
+
+		// when
+		MenuProduct menuProduct = new MenuProduct(product, quantity);
+
+		// & then
+		assertAll(
+			() -> assertThat(menuProduct).isNotNull(),
+			() -> assertThat(menuProduct.getProduct()).isEqualTo(product),
+			() -> assertThat(menuProduct.getQuantity()).isEqualTo(quantity)
+		);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductsTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductsTest.java
@@ -1,0 +1,41 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductFixture;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductsFixture;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
+
+public class MenuProductsTest {
+
+	@Test
+	void 메뉴상품들을_생성할_수_있다() {
+		// given
+		MenuProduct menuProduct1 = MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1);
+		MenuProduct menuProduct2 = MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2);
+
+		// when
+		new MenuProducts(Arrays.asList(menuProduct1, menuProduct2));
+	}
+
+	@Test
+	void 메뉴상품들의_전체_금액을_구할_수_있다() {
+		// given
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
+
+		// when
+		Price actual = menuProducts.getTotalPrice();
+
+		// then
+		assertThat(actual).isEqualTo(new Price(new BigDecimal(53_000L)));
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductsTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuProductsTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +24,17 @@ public class MenuProductsTest {
 
 		// when
 		new MenuProducts(Arrays.asList(menuProduct1, menuProduct2));
+	}
+
+	@Test
+	void 메뉴상품들은_한개_이상이어야만_생성할_수_있다() {
+		// given
+		List<MenuProduct> empty = Collections.emptyList();
+
+		// when & then
+		assertThatThrownBy(
+			() -> new MenuProducts(empty)
+		).isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
@@ -1,0 +1,35 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.fixture.MenuGroupFixture;
+
+public class MenuTest {
+	@Test
+	void 메뉴를_생성할_수_있다() {
+		// given
+		DisplayedName name = new DisplayedName("후라이드+후라이드", text -> false);
+		Price price = new Price(new BigDecimal(19_000L));
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+
+		// when
+		Menu menu = new Menu(name, price, menuGroup);
+
+		// & then
+		assertAll(
+			() -> assertThat(menu).isNotNull(),
+			() -> assertThat(menu.getId()).isNotNull(),
+			() -> assertThat(menu.getName()).isEqualTo(name),
+			() -> assertThat(menu.getPrice()).isEqualTo(price),
+			() -> assertThat(menu.getMenuGroup()).isEqualTo(menuGroup)
+		);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
@@ -5,31 +5,63 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductFixture;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductsFixture;
 import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
 import kitchenpos.menus.tobe.domain.menugroup.fixture.MenuGroupFixture;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
 
 public class MenuTest {
-	@Test
-	void 메뉴를_생성할_수_있다() {
+	@ParameterizedTest
+	@ValueSource(strings = {"10000", "53000"})
+	void 메뉴를_생성할_수_있다(long value) {
 		// given
-		DisplayedName name = new DisplayedName("후라이드+후라이드", text -> false);
-		Price price = new Price(new BigDecimal(19_000L));
+		DisplayedName name = new DisplayedName("강정+양념", text -> false);
+		Price price = new Price(new BigDecimal(value));
+		boolean displayed = true;
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
 		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
 
 		// when
-		Menu menu = new Menu(name, price, menuGroup);
+		Menu menu = new Menu(name, price, displayed, menuProducts, menuGroup);
 
-		// & then
+		// then
 		assertAll(
 			() -> assertThat(menu).isNotNull(),
 			() -> assertThat(menu.getId()).isNotNull(),
 			() -> assertThat(menu.getName()).isEqualTo(name),
 			() -> assertThat(menu.getPrice()).isEqualTo(price),
-			() -> assertThat(menu.getMenuGroup()).isEqualTo(menuGroup)
+			() -> assertThat(menu.isDisplayed()).isEqualTo(displayed),
+			() -> assertThat(menu.getMenuGroup()).isEqualTo(menuGroup),
+			() -> assertThat(menu.getMenuProducts()).isNotNull(),
+			() -> assertThat(menu.getMenuProducts().getValues()).isNotEmpty()
 		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"54000", "100000"})
+	void 메뉴의_가격이_메뉴상품들의_전체_가격보다_크다면_메뉴를_생성할_수_없다(long value) {
+		// given
+		DisplayedName name = new DisplayedName("강정+양념", text -> false);
+		Price price = new Price(new BigDecimal(value));
+		boolean displayed = true;
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+
+		// when & then
+		assertThatThrownBy(
+			() -> new Menu(name, price, displayed, menuProducts, menuGroup)
+		).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/MenuTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuFixture;
 import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductFixture;
 import kitchenpos.menus.tobe.domain.menu.fixture.MenuProductsFixture;
 import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
@@ -62,6 +64,57 @@ public class MenuTest {
 		// when & then
 		assertThatThrownBy(
 			() -> new Menu(name, price, displayed, menuProducts, menuGroup)
+		).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 메뉴를_공개할_수_있다() {
+		// given
+		Menu menu = MenuFixture.숨김_메뉴();
+
+		// when
+		menu.display();
+
+		// then
+		assertThat(menu.isDisplayed()).isTrue();
+	}
+
+	@Test
+	void 메뉴를_숨길_수_있다() {
+		// given
+		Menu menu = MenuFixture.전시_메뉴();
+
+		// when
+		menu.hide();
+
+		// then
+		assertThat(menu.isDisplayed()).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"10000", "53000"})
+	void 메뉴_가격을_변경할_수_있다(long value) {
+		// given
+		Price price = new Price(new BigDecimal(value));
+		Menu menu = MenuFixture.전시_메뉴();
+
+		// when
+		menu.changePrice(price);
+
+		// then
+		assertThat(menu.getPrice()).isEqualTo(price);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"54000", "100000"})
+	void 변경할_메뉴_가격이_메뉴상품들의_전체_가격보다_크다면_메뉴_가격을_변경할_수_없다(long value) {
+		// given
+		Price price = new Price(new BigDecimal(value));
+		Menu menu = MenuFixture.전시_메뉴();
+
+		// when & then
+		assertThatThrownBy(
+			() -> menu.changePrice(price)
 		).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/QuantityTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/QuantityTest.java
@@ -1,0 +1,39 @@
+package kitchenpos.menus.tobe.domain.menu;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class QuantityTest {
+	@ParameterizedTest
+	@ValueSource(strings = {"0", "10"})
+	void 수량을_생성할_수_있다(long value) {
+		// given & when
+		Quantity quantity = new Quantity(value);
+
+		// then
+		assertThat(quantity.getValue()).isEqualTo(value);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"-10", "-1"})
+	void 수량은_0_이상이어야_한다(long value) {
+		// given & when & then
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new Quantity(value));
+	}
+
+	@Test
+	void 동등성() {
+		// given
+		long value = 10000L;
+
+		// when
+		final Quantity quantity1 = new Quantity(value);
+		final Quantity quantity2 = new Quantity(value);
+
+		// then
+		assertThat(quantity1).isEqualTo(quantity2);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuFixture.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuFixture.java
@@ -1,0 +1,45 @@
+package kitchenpos.menus.tobe.domain.menu.fixture;
+
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
+import kitchenpos.common.domain.fixture.DisplayedNameFixture;
+import kitchenpos.common.domain.fixture.PriceFixture;
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuProducts;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.fixture.MenuGroupFixture;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
+
+public class MenuFixture {
+	public static Menu 전시_메뉴() {
+		DisplayedName name = DisplayedNameFixture.이름("강정+양념");
+		Price price = PriceFixture.가격(19_000L);
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+		return new Menu(name, price, true, menuProducts, menuGroup);
+	}
+
+	public static Menu 전시_메뉴(Price price) {
+		DisplayedName name = DisplayedNameFixture.이름("강정+양념");
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+		return new Menu(name, price, true, menuProducts, menuGroup);
+	}
+
+	public static Menu 숨김_메뉴() {
+		DisplayedName name = DisplayedNameFixture.이름("강정+양념");
+		Price price = PriceFixture.가격(19_000L);
+		MenuProducts menuProducts = MenuProductsFixture.메뉴상품들(
+			MenuProductFixture.메뉴상품(ProductFixture.상품("강정치킨", 17_000L), 1),
+			MenuProductFixture.메뉴상품(ProductFixture.상품("양념치킨", 18_000L), 2)
+		);
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+		return new Menu(name, price, false, menuProducts, menuGroup);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuFixture.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuFixture.java
@@ -32,6 +32,12 @@ public class MenuFixture {
 		return new Menu(name, price, true, menuProducts, menuGroup);
 	}
 
+	public static Menu 전시_메뉴(Price price, MenuProducts menuProducts) {
+		DisplayedName name = DisplayedNameFixture.이름("강정+양념");
+		MenuGroup menuGroup = MenuGroupFixture.메뉴그룹("추천메뉴");
+		return new Menu(name, price, true, menuProducts, menuGroup);
+	}
+
 	public static Menu 숨김_메뉴() {
 		DisplayedName name = DisplayedNameFixture.이름("강정+양념");
 		Price price = PriceFixture.가격(19_000L);

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuProductFixture.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuProductFixture.java
@@ -1,0 +1,11 @@
+package kitchenpos.menus.tobe.domain.menu.fixture;
+
+import kitchenpos.menus.tobe.domain.menu.MenuProduct;
+import kitchenpos.menus.tobe.domain.menu.Quantity;
+import kitchenpos.products.tobe.domain.Product;
+
+public class MenuProductFixture {
+	public static MenuProduct 메뉴상품(Product product, long quantity) {
+		return new MenuProduct(product, new Quantity(quantity));
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuProductsFixture.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menu/fixture/MenuProductsFixture.java
@@ -1,0 +1,12 @@
+package kitchenpos.menus.tobe.domain.menu.fixture;
+
+import java.util.Arrays;
+
+import kitchenpos.menus.tobe.domain.menu.MenuProduct;
+import kitchenpos.menus.tobe.domain.menu.MenuProducts;
+
+public class MenuProductsFixture {
+	public static MenuProducts 메뉴상품들(MenuProduct... menuProducts) {
+		return new MenuProducts(Arrays.asList(menuProducts));
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroupTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menugroup/MenuGroupTest.java
@@ -1,0 +1,25 @@
+package kitchenpos.menus.tobe.domain.menugroup;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MenuGroupTest {
+
+	@Test
+	void 메뉴그룹을_생성할_수_있다() {
+		// given
+		Name name = new Name("추천메뉴");
+
+		// when
+		MenuGroup menuGroup = new MenuGroup(name);
+
+		// & then
+		assertAll(
+			() -> assertThat(menuGroup).isNotNull(),
+			() -> assertThat(menuGroup.getId()).isNotNull(),
+			() -> assertThat(menuGroup.getName()).isEqualTo(name)
+		);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menugroup/NameTest.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menugroup/NameTest.java
@@ -1,0 +1,41 @@
+package kitchenpos.menus.tobe.domain.menugroup;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class NameTest {
+	@Test
+	void 이름을_생성할_수_있다() {
+		// given
+		String value = "추천메뉴";
+
+		// when
+		Name name = new Name(value);
+
+		// then
+		assertThat(name.getValue()).isEqualTo(value);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 빈_값이일_경우_이름을_생성할_수_없다(String value) {
+		// given & when & then
+		assertThatThrownBy(
+			() -> new Name(value)
+		).isInstanceOf(IllegalArgumentException.class);
+
+	}
+
+	@Test
+	void 동등성() {
+		// given & when
+		Name name1 = new Name("추천메뉴");
+		Name name2 = new Name("추천메뉴");
+
+		// then
+		assertThat(name1).isEqualTo(name2);
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/domain/menugroup/fixture/MenuGroupFixture.java
+++ b/src/test/java/kitchenpos/menus/tobe/domain/menugroup/fixture/MenuGroupFixture.java
@@ -1,0 +1,10 @@
+package kitchenpos.menus.tobe.domain.menugroup.fixture;
+
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.Name;
+
+public class MenuGroupFixture {
+	public static MenuGroup 메뉴그룹(String name) {
+		return new MenuGroup(new Name(name));
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/infra/menu/InMemoryMenuRepository.java
+++ b/src/test/java/kitchenpos/menus/tobe/infra/menu/InMemoryMenuRepository.java
@@ -1,0 +1,51 @@
+package kitchenpos.menus.tobe.infra.menu;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
+
+public class InMemoryMenuRepository implements MenuRepository {
+	private final Map<UUID, Menu> menus = new HashMap<>();
+
+	@Override
+	public Menu save(final Menu menu) {
+		menus.put(menu.getId(), menu);
+		return menu;
+	}
+
+	@Override
+	public Optional<Menu> findById(final UUID id) {
+		return Optional.ofNullable(menus.get(id));
+	}
+
+	@Override
+	public List<Menu> findAll() {
+		return new ArrayList<>(menus.values());
+	}
+
+	@Override
+	public List<Menu> findAllByIdIn(final List<UUID> ids) {
+		return menus.values()
+			.stream()
+			.filter(menu -> ids.contains(menu.getId()))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<Menu> findAllByProductId(final UUID productId) {
+		return menus.values()
+			.stream()
+			.filter(menu -> menu.getMenuProducts()
+                .getValues()
+				.stream()
+				.anyMatch(menuProduct -> menuProduct.getProduct().getId().equals(productId)))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/test/java/kitchenpos/menus/tobe/infra/menugroup/InMemoryMenuGroupRepository.java
+++ b/src/test/java/kitchenpos/menus/tobe/infra/menugroup/InMemoryMenuGroupRepository.java
@@ -1,0 +1,31 @@
+package kitchenpos.menus.tobe.infra.menugroup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroup;
+import kitchenpos.menus.tobe.domain.menugroup.MenuGroupRepository;
+
+public class InMemoryMenuGroupRepository implements MenuGroupRepository {
+	private final Map<UUID, MenuGroup> menuGroups = new HashMap<>();
+
+	@Override
+	public MenuGroup save(final MenuGroup menuGroup) {
+		menuGroups.put(menuGroup.getId(), menuGroup);
+		return menuGroup;
+	}
+
+	@Override
+	public Optional<MenuGroup> findById(final UUID id) {
+		return Optional.ofNullable(menuGroups.get(id));
+	}
+
+	@Override
+	public List<MenuGroup> findAll() {
+		return new ArrayList<>(menuGroups.values());
+	}
+}

--- a/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -14,6 +16,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import kitchenpos.menus.tobe.domain.menu.Menu;
+import kitchenpos.menus.tobe.domain.menu.MenuProduct;
+import kitchenpos.menus.tobe.domain.menu.MenuProducts;
+import kitchenpos.menus.tobe.domain.menu.MenuRepository;
+import kitchenpos.menus.tobe.domain.menu.Quantity;
+import kitchenpos.menus.tobe.domain.menu.fixture.MenuFixture;
+import kitchenpos.menus.tobe.infra.menu.InMemoryMenuRepository;
 import kitchenpos.products.tobe.domain.fixture.ProductFixture;
 import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
@@ -28,12 +37,14 @@ public class ProductServiceTest {
 	private ProductRepository productRepository;
 	private Profanities profanities;
 	private ProductService productService;
+	private MenuRepository menuRepository;
 
 	@BeforeEach
 	void setUp() {
 		productRepository = new InMemoryProductRepository();
 		profanities = text -> Stream.of("비속어", "욕설").anyMatch(text::contains);
-		productService = new ProductService(productRepository, profanities);
+		menuRepository = new InMemoryMenuRepository();
+		productService = new ProductService(productRepository, profanities, menuRepository);
 	}
 
 	@Test
@@ -103,7 +114,27 @@ public class ProductServiceTest {
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
-	// TODO : 상품의 가격이 변경될 때 메뉴의 가격이 메뉴에 속한 상품 금액의 합보다 크면 메뉴가 숨겨진다.
+	@Test
+	void 상품의_가격이_변경될_때_메뉴의_가격이_메뉴에_속한_상품_금액의_합보다_크면_메뉴가_숨겨진다() {
+		// given
+		Product givenProduct = ProductFixture.상품("후라이드", 16_000L);
+		productRepository.save(givenProduct);
+
+		Menu givenMenu = MenuFixture.전시_메뉴(
+			new Price(new BigDecimal(15_000L)),
+			new MenuProducts(Collections.singletonList(new MenuProduct(givenProduct, new Quantity(2L)))));
+		menuRepository.save(givenMenu);
+
+		ProductPriceChangeRequest request = new ProductPriceChangeRequest(100L);
+
+		// when
+		Product product = productService.changePrice(givenProduct.getId(), request);
+		Menu menu = menuRepository.findById(givenMenu.getId()).get();
+
+		// then
+		assertThat(product.getPrice()).isEqualTo(new Price(new BigDecimal(100L)));
+		assertThat(menu.isDisplayed()).isFalse();
+	}
 
 	@Test
 	void 상품의_목록을_조회할_수_있다() {

--- a/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import kitchenpos.TobeFixtures;
+import kitchenpos.products.tobe.domain.fixture.ProductFixture;
 import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
 import kitchenpos.products.tobe.domain.Product;
@@ -79,7 +79,7 @@ public class ProductServiceTest {
 	@Test
 	void 상품의_가격을_변경할_수_있다() {
 		// given
-		Product given = TobeFixtures.product("후라이드", 16_000L);
+		Product given = ProductFixture.상품("후라이드", 16_000L);
 		UUID givenId = productRepository.save(given).getId();
 		ProductPriceChangeRequest request = new ProductPriceChangeRequest(15_000L);
 
@@ -94,7 +94,7 @@ public class ProductServiceTest {
 	@ValueSource(strings = "-1000")
 	void 상품의_가격이_올바르지_않으면_변경할_수_없다(long price) {
 		// given
-		Product given = TobeFixtures.product("후라이드", 16_000L);
+		Product given = ProductFixture.상품("후라이드", 16_000L);
 		UUID givenId = productRepository.save(given).getId();
 		ProductPriceChangeRequest request = new ProductPriceChangeRequest(price);
 
@@ -108,8 +108,8 @@ public class ProductServiceTest {
 	@Test
 	void 상품의_목록을_조회할_수_있다() {
 		// given
-		productRepository.save(TobeFixtures.product("후라이드", 16_000L));
-		productRepository.save(TobeFixtures.product("양념치킨", 16_000L));
+		productRepository.save(ProductFixture.상품("후라이드", 16_000L));
+		productRepository.save(ProductFixture.상품("양념치킨", 16_000L));
 
 		// when
 		List<Product> actual = productService.findAll();

--- a/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/products/tobe/application/ProductServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -16,11 +15,11 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import kitchenpos.TobeFixtures;
-import kitchenpos.products.tobe.domain.DisplayedName;
-import kitchenpos.products.tobe.domain.Price;
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
 import kitchenpos.products.tobe.domain.Product;
 import kitchenpos.products.tobe.domain.ProductRepository;
-import kitchenpos.products.tobe.domain.Profanities;
+import kitchenpos.common.domain.Profanities;
 import kitchenpos.products.tobe.infra.InMemoryProductRepository;
 import kitchenpos.products.tobe.ui.ProductCreateRequest;
 import kitchenpos.products.tobe.ui.ProductPriceChangeRequest;

--- a/src/test/java/kitchenpos/products/tobe/domain/ProductTest.java
+++ b/src/test/java/kitchenpos/products/tobe/domain/ProductTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import kitchenpos.common.domain.DisplayedName;
+import kitchenpos.common.domain.Price;
+
 public class ProductTest {
 	@Test
 	void 상품을_생성할_수_있다() {

--- a/src/test/java/kitchenpos/products/tobe/domain/fixture/ProductFixture.java
+++ b/src/test/java/kitchenpos/products/tobe/domain/fixture/ProductFixture.java
@@ -1,4 +1,4 @@
-package kitchenpos;
+package kitchenpos.products.tobe.domain.fixture;
 
 import java.math.BigDecimal;
 
@@ -6,8 +6,8 @@ import kitchenpos.common.domain.DisplayedName;
 import kitchenpos.common.domain.Price;
 import kitchenpos.products.tobe.domain.Product;
 
-public class TobeFixtures {
-	public static Product product(final String name, final long price) {
+public class ProductFixture {
+	public static Product 상품(final String name, final long price) {
 		return new Product(
 			new DisplayedName(name, (text) -> false),
 			new Price(new BigDecimal(price))


### PR DESCRIPTION
리뷰어님, 이번에도 잘 부탁드립니다 :)

몇가지 궁금한 점이 있어서 여쭤봅니다.

### ID 생성을 DB 에게 위임하는 경우, TC 작성

`MenuProduct` 는 ID 생성을 DB 에게 위임하고 있는데, 테스트를 작성할 때 어떻게 값을 생성하는게 좋을까요?
생각나는 방법으로는 테스트 환경일때만 ID 를 1씩 증가시켜서 세팅하는 방법이 있을 것 같긴 한데 더 좋은 방법을 알고 계신 것이 있을까요?

### BC 간 접근 방식

현재 프로젝트는 BC 간 패키지로 분리가 되어있기에 간편하게 `import` 해서 사용하면 되는 것 같은데요,
만약 멀티 모듈 프로젝트일 경우에는 API 호출을 통해 분리하는 것이 좋을까요?
예를 들면, `MenuProducts` 를 만들기 위해서 `Product` 단건 조회 API 를 N 건 호출하게 될텐데
성능 이슈를 고려하여 여러 `Product` 를 한번에 API 로 조회하는 등의 작업이 필요할 수 있다는 생각이 드네요.

### 일급 컬렉션과 Embedded

`List<MenuProduct>` 를 일급 컬렉션 `MenuProducts` 로 사용하려고 `@Embedded` 를 붙여서 사용하는데요,
`MenuRepository.save()` 후 `MenuProducts` 를 가져오면 null 로 조회되는 문제가 있습니다.
(`MenuRepository.findAll()` 같은 경우에는 잘 조회가 되는데 ㅠ)
연관관계의 매핑이 잘못된 것인지 따로 JPA 에서 지원하는 기능이 있는 것인지 궁금합니다.
자료를 찾아보긴 했는데 아직 해결을 하지 못해서 여쭤봅니다!
