### PR TITLE
상품 리팩토림

### DIFF
--- a/src/main/java/kitchenpos/products/tobe/domain/Product.java
+++ b/src/main/java/kitchenpos/products/tobe/domain/Product.java
@@ -1,0 +1,51 @@
+package kitchenpos.products.tobe.domain;
+
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Table(name = "product")
+@Entity
+public class Product {
+  @Column(name = "id", columnDefinition = "varbinary(16)")
+  @Id
+  private UUID id;
+
+  @Embedded
+  @Column(name = "name", nullable = false)
+  private ProductName name;
+
+  @Embedded
+  @Column(name = "price", nullable = false)
+  private ProductPrice price;
+
+  protected Product() {
+  }
+
+  public Product(UUID id, ProductName name, ProductPrice price) {
+    this.id = id;
+    this.name = name;
+    this.price = price;
+  }
+
+  public Product(UUID id, String name, BigDecimal price) {
+    this(id, new ProductName(name), new ProductPrice(price));
+  }
+
+  public void changePrice(BigDecimal price) {
+    this.price = new ProductPrice(price);
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public ProductName getName() {
+    return name;
+  }
+
+  public ProductPrice getPrice() {
+    return price;
+  }
+}

--- a/src/main/java/kitchenpos/products/tobe/domain/ProductName.java
+++ b/src/main/java/kitchenpos/products/tobe/domain/ProductName.java
@@ -1,0 +1,37 @@
+package kitchenpos.products.tobe.domain;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class ProductName {
+
+  private String name;
+
+  protected ProductName() {
+  }
+
+  public ProductName(String name) {
+    validate(name);
+    this.name = name;
+  }
+
+  private void validate(String name) {
+    if (Objects.isNull(name) || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("이름은 비어있을 수 없습니다.");
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProductName that = (ProductName) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/src/main/java/kitchenpos/products/tobe/domain/ProductPrice.java
+++ b/src/main/java/kitchenpos/products/tobe/domain/ProductPrice.java
@@ -1,0 +1,40 @@
+package kitchenpos.products.tobe.domain;
+
+import javax.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Embeddable
+public class ProductPrice {
+
+  private static final BigDecimal ZERO = BigDecimal.ZERO;
+
+  private BigDecimal price;
+
+  protected ProductPrice() {
+  }
+
+  public ProductPrice(BigDecimal price) {
+    validate(price);
+    this.price = price;
+  }
+
+  private void validate(BigDecimal price) {
+    if (price == null || price.compareTo(ZERO) < 0) {
+      throw new IllegalArgumentException("가격은 0원 이상이어야 합니다.");
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProductPrice that = (ProductPrice) o;
+    return Objects.equals(price, that.price);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(price);
+  }
+}

--- a/src/test/java/kitchenpos/products/tobe/domain/ProductFixture.java
+++ b/src/test/java/kitchenpos/products/tobe/domain/ProductFixture.java
@@ -1,0 +1,8 @@
+package kitchenpos.products.tobe.domain;
+
+import java.math.BigDecimal;
+
+public class ProductFixture {
+  public static final Product 상품 = new Product(null, "name", BigDecimal.valueOf(1000L));
+
+}

--- a/src/test/java/kitchenpos/products/tobe/domain/ProductTest.java
+++ b/src/test/java/kitchenpos/products/tobe/domain/ProductTest.java
@@ -1,0 +1,80 @@
+package kitchenpos.products.tobe.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static kitchenpos.products.tobe.domain.ProductFixture.상품;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ProductTest {
+
+  public static final BigDecimal PRICE = BigDecimal.valueOf(1000L);
+  public static final BigDecimal CHANGE_PRICE = BigDecimal.valueOf(2000L);
+  public static final BigDecimal MINUS_PRICE = BigDecimal.valueOf(-1000L);
+
+  private static Stream<Arguments> provideBigDecimalForIsNotNullAndMinusValue() {
+    return Stream.of(
+      Arguments.of((BigDecimal) null),
+      Arguments.of(MINUS_PRICE)
+    );
+  }
+
+  @Test
+  @DisplayName("상품을 등록할 수 있다.")
+  void test1() {
+    assertThatCode(
+      () -> new Product(null, "name", PRICE)
+    ).doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @DisplayName("상품 이름이 존재하지 않으면 IllegalArgumentException 예외 발생")
+  @NullAndEmptySource
+  void test2(String name) {
+    assertThatThrownBy(
+      () -> new Product(null, name, BigDecimal.valueOf(1000L))
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("상품 가격에 음수이면 IllegalArgumentException 예외 발생")
+  void test3() {
+    assertThatThrownBy(
+      () -> new Product(null, "name", BigDecimal.valueOf(-1000L))
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @DisplayName("존재하지 않으면 IllegalArgumentException 예외 발생")
+  @MethodSource("provideBigDecimalForIsNotNullAndMinusValue")
+  void test4(BigDecimal price) {
+    assertThatThrownBy(
+      () -> new Product(null, "name", price)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("상품의 가격을 변경할 수 있다.")
+  void test5() {
+    assertAll(
+      () -> assertDoesNotThrow(() -> 상품.changePrice(CHANGE_PRICE)),
+      () -> assertThat(상품.getPrice()).isEqualTo(new ProductPrice(CHANGE_PRICE))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideBigDecimalForIsNotNullAndMinusValue")
+  @DisplayName("변경하는 상품의 가격이 음수거나 존재하지 않으면 IllegalArgumentException 예외 발생")
+  void test6(BigDecimal price) {
+    assertThatThrownBy(
+      () -> 상품.changePrice(MINUS_PRICE)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
안녕하세요 ☺️
상품 리팩토링을 진행하면서 비즈니스 규칙이 존재하는 상태들은 전부 값 객체로 나타냈습니다. 그 외에는 비속어 필터링은 외부에서 접근한다고 판단해 값 객체에서 필터링을 진행하지 않고 도메인 서비스에서 접근하는 게 맞다고 판단해 비속어를 확인하지 않았습니다.
만약 값 객체를 표현할때, JPA로 진행하게 된다면 불변이라는 의미를 내포하는 방법은 기본 생성자를 `protected` 접근 제어자를 사용하는 방법 말고는 없는 거겠죠...? 🥺 
이번 리뷰 잘부탁드립니다. ☺️